### PR TITLE
US3 merchant bulk discount delete

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -105,17 +105,23 @@ p {
 
 table {
     width: 100%;
-
 }
+
 th {
     color: white;
     background: rgb(158, 158, 158);
 }
+
 tr {
     background: rgb(230, 230, 230);
 }
+
 table, th, td {
     border: 1px solid;
     border-collapse: collapse;
     text-align: center;
-  }
+}
+
+br { 
+    line-height: 0;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -60,6 +60,11 @@
     color: green
 }
 
+.nowrap {
+    white-space: nowrap;
+    display: inline-block;
+}
+
 #incomplete-invoices {
     margin: 0 25px 0 25px;
     width: 40%;
@@ -87,6 +92,14 @@ a {
 }
 
 h3 {
+    display: inline-block;
+}
+
+h4 {
+    display: inline-block;
+}
+
+p {
     display: inline-block;
 }
 

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -18,6 +18,13 @@ class MerchantDiscountsController < ApplicationController
     redirect_decider(discount, params) 
   end
 
+  def destroy 
+    discount = Discount.find(params[:id])
+    discount.destroy 
+
+    redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
+  end
+
   private 
   def merchant_discount_params 
     params.permit(:discount, :threshold)

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -1,14 +1,15 @@
 <div id="header">
     <%= render "shared/merchant_facade_header" %>
 </div>
-<br><br>
+<br>
 
 <% flash.each do |type, msg| %>
     <div class='flash_green'><%= msg %></div>
 <% end %>
-<br>
 
-<%= link_to 'Create New Discount', new_merchant_discount_path(@facade.merchant) %><br>
+
+<%= link_to 'Create New Discount', new_merchant_discount_path(@facade.merchant) %>
+<br>
 
 <h3>Merchant Discounts</h3>
 <% @facade.discounts_display.each_with_index do |discount, index| %>

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -8,14 +8,18 @@
 <% end %>
 <br>
 
-<%= link_to 'Create New Discount', new_merchant_discount_path(@facade.merchant) %>
+<%= link_to 'Create New Discount', new_merchant_discount_path(@facade.merchant) %><br>
 
-<h4>Merchant Discounts</h4>
+<h3>Merchant Discounts</h3>
 <% @facade.discounts_display.each_with_index do |discount, index| %>
-  <div id="discount-<%=index %>">
-      <h5><%= link_to "Discount #{index + 1}", merchant_discount_path(@facade.merchant, @facade.discounts[index]) %></h5>
-      <p><%= discount %></p>
-  </div>
+    <div id="discount-<%=index %>">
+        <div class="nowrap">
+            <h4><%= link_to "Discount #{index + 1}:", merchant_discount_path(@facade.merchant, @facade.discounts[index]) %></h4>
+            <p><%= discount %></p> 
+        </div>
+        <br>
+        <%= link_to 'Delete Discount', merchant_discount_path(@facade.merchant, @facade.discounts[index]), method: :delete %>
+    </div>
 <% end %>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resources :merchants, only: [:index]  do
     resources :items, only: [:index, :show, :new, :create, :edit, :update], :controller => 'merchant_items'
     resources :invoices, only: [:index, :show, :update], :controller => 'merchant_invoices'
-    resources :discounts, only: [:index, :show, :new, :create], :controller => 'merchant_discounts'
+    resources :discounts, only: [:index, :show, :new, :create, :destroy], :controller => 'merchant_discounts'
   end
 
   resources :admin, only: [:index]

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -72,4 +72,30 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/new"
   end
+
+  # US3
+  # Merchant Bulk Discount Delete
+  # As a merchant
+  # When I visit my bulk discounts index
+  # Then next to each bulk discount I see a link to delete it
+  # When I click this link
+  # Then I am redirected back to the bulk discounts index page
+  # And I no longer see the discount listed
+  it 'has a link to delete each Discount' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    visit merchant_discounts_path(merchant_1)
+    
+    within('#discount-0') do 
+      click_link 'Delete Discount' 
+    end
+
+    expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts"
+    expect(page).to have_content 'Discount has been successfully deleted.' 
+    expect(page).to_not have_content 'Discount Amount: 20.0 percent, Threshold: 10 items'
+  end
 end


### PR DESCRIPTION
Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed