### PR TITLE
US5 merchant bulk discount edit

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -31,9 +31,8 @@ class MerchantDiscountsController < ApplicationController
 
   def update 
     facade = MerchantDiscountsFacade.new(params)
-    facade.discount.update(merchant_discount_params)
-
-    redirect_to merchant_discount_path(facade.merchant, facade.discount), notice: "Discount has been successfully updated."
+    
+    update_router(facade) 
   end
 
 
@@ -48,5 +47,13 @@ class MerchantDiscountsController < ApplicationController
     else 
       redirect_to new_merchant_discount_path(params[:merchant_id]), alert: "Error: Please fill in all fields with numbers."
     end
+  end
+
+  def update_router(facade)
+    if facade.discount.update(merchant_discount_params)
+      redirect_to merchant_discount_path(facade.merchant, facade.discount), notice: "Discount has been successfully updated."
+    else
+      redirect_to edit_merchant_discount_path(facade.merchant, facade.discount), alert: "Error: Discount was not updated. Please fill out the form using numbers."
+    end 
   end
 end

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -29,6 +29,14 @@ class MerchantDiscountsController < ApplicationController
     @facade = MerchantDiscountsFacade.new(params)
   end
 
+  def update 
+    facade = MerchantDiscountsFacade.new(params)
+    facade.discount.update(merchant_discount_params)
+
+    redirect_to merchant_discount_path(facade.merchant, facade.discount), notice: "Discount has been successfully updated."
+  end
+
+
   private 
   def merchant_discount_params 
     params.permit(:discount, :threshold)

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -25,6 +25,10 @@ class MerchantDiscountsController < ApplicationController
     redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
   end
 
+  def edit 
+    @facade = MerchantDiscountsFacade.new(params)
+  end
+
   private 
   def merchant_discount_params 
     params.permit(:discount, :threshold)

--- a/app/views/merchant_discounts/edit.html.erb
+++ b/app/views/merchant_discounts/edit.html.erb
@@ -3,7 +3,7 @@
 </div>
 <br>
 
-<div class='section-title'><h1>Edit Merchant Discount </h1></div>
+<div class='section-title'><h2>Edit Merchant Discount </h2></div>
 
 <% flash.each do |type, msg| %>
     <div class='flash_red'><%= msg %></div>

--- a/app/views/merchant_discounts/edit.html.erb
+++ b/app/views/merchant_discounts/edit.html.erb
@@ -1,0 +1,22 @@
+<div id="header">
+    <%= render "shared/merchant_facade_header" %>
+</div>
+<br>
+
+<div class='section-title'><h1>Edit Merchant Discount </h1></div>
+
+<% flash.each do |type, msg| %>
+    <div class='flash_red'><%= msg %></div>
+<% end %>
+
+<%= form_with url: merchant_discount_path(@facade.merchant, @facade.discount), method: :patch, local: true do |f| %>
+  <%= f.label :threshold, 'Number of an Item that must be bought to trigger the discount:' %>
+  <%= f.text_field :threshold, value: @facade.discount.threshold %>
+  <br>
+  
+  <%= f.label :discount, 'Percentage Discount:' %>
+  <%= f.text_field :discount, value: @facade.discount.discount %>%
+  <br>
+
+  <%= submit_tag('Update Discount Information') %>
+<% end %>

--- a/app/views/merchant_discounts/show.html.erb
+++ b/app/views/merchant_discounts/show.html.erb
@@ -1,3 +1,8 @@
+<div id="header">
+    <%= render "shared/merchant_facade_header" %>
+</div>
+<br>
+
 <h3> Discount Details </h3>
 
 Quantity Threshold: <%= @facade.discount.threshold %>

--- a/app/views/merchant_discounts/show.html.erb
+++ b/app/views/merchant_discounts/show.html.erb
@@ -3,10 +3,14 @@
 </div>
 <br>
 
-<h3> Discount Details </h3>
+<% flash.each do |type, msg| %>
+    <div class='flash_green'><%= msg %></div>
+<% end %>
 
+<h3> Discount Details </h3><br>
 Quantity Threshold: <%= @facade.discount.threshold %>
 <br>
 Percentage Discount: <%= @facade.discount.discount %>%
+<br><br>
 
 <%= link_to 'Edit Discount', edit_merchant_discount_path(@facade.merchant, @facade.discount) %>

--- a/app/views/merchant_discounts/show.html.erb
+++ b/app/views/merchant_discounts/show.html.erb
@@ -3,3 +3,5 @@
 Quantity Threshold: <%= @facade.discount.threshold %>
 <br>
 Percentage Discount: <%= @facade.discount.discount %>%
+
+<%= link_to 'Edit Discount', edit_merchant_discount_path(@facade.merchant, @facade.discount) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resources :merchants, only: [:index]  do
     resources :items, only: [:index, :show, :new, :create, :edit, :update], :controller => 'merchant_items'
     resources :invoices, only: [:index, :show, :update], :controller => 'merchant_invoices'
-    resources :discounts, only: [:index, :show, :new, :create, :destroy], :controller => 'merchant_discounts'
+    resources :discounts, only: [:index, :show, :new, :create, :destroy, :edit], :controller => 'merchant_discounts'
   end
 
   resources :admin, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resources :merchants, only: [:index]  do
     resources :items, only: [:index, :show, :new, :create, :edit, :update], :controller => 'merchant_items'
     resources :invoices, only: [:index, :show, :update], :controller => 'merchant_invoices'
-    resources :discounts, only: [:index, :show, :new, :create, :destroy, :edit], :controller => 'merchant_discounts'
+    resources :discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update], :controller => 'merchant_discounts'
   end
 
   resources :admin, only: [:index]

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -48,4 +48,22 @@ RSpec.describe 'Merchant Discount Edit Page', type: :feature do
     expect(page).to have_content 'Quantity Threshold: 20'
     expect(page).to have_content 'Percentage Discount: 30.5%'
   end
+
+  it 'is redirected to the Edit page if the form is not filled out correctly' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    visit edit_merchant_discount_path(merchant_1, discount_1a)
+
+    fill_in 'Number of an Item that must be bought to trigger the discount:', with: ''
+    fill_in 'Percentage Discount:', with: 'forty' 
+    click_on 'Update Discount Information' 
+    save_and_open_page
+
+    expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1a.id}/edit"
+    expect(page).to have_content "Error: Discount was not updated. Please fill out the form using numbers."
+  end
 end

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper' 
+
+RSpec.describe 'Merchant Discount Edit Page', type: :feature do 
+  # US 5
+  # Merchant Bulk Discount Edit
+  # in spec/features/merchants/discounts/show_spec: 
+    # As a merchant
+    # When I visit my bulk discount show page
+    # Then I see a link to edit the bulk discount
+    # When I click this link
+    # Then I am taken to a new page with a form to edit the discount
+
+  # And I see that the discounts current attributes are pre-populuated in the form
+  it 'has pre-populated entries in the form' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    visit edit_merchant_discount_path(merchant_1, discount_1b)
+
+    expect(page).to have_field('Number of an Item that must be bought to trigger the discount:', with: discount_1b.threshold) 
+    expect(page).to have_field('Percentage Discount:', with: discount_1b.discount) 
+
+    expect(page).to_not have_field('Number of an Item that must be bought to trigger the discount:', with: discount_1a.threshold) 
+    expect(page).to_not have_field('Percentage Discount:', with: discount_1a.discount) 
+  end
+
+  # When I change any/all of the information and click submit
+  # Then I am redirected to the bulk discount's show page
+  # And I see that the discount's attributes have been updated
+  it 'can update a Discount and redirect to the Discount Show page' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    visit edit_merchant_discount_path(merchant_1, discount_1b)
+
+    fill_in 'Number of an Item that must be bought to trigger the discount:', with: '20'
+    fill_in 'Percentage Discount:', with: '30.5' 
+    click_on 'Update Discount Information' 
+
+    
+
+  end
+end

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe 'Merchant Discount Edit Page', type: :feature do
     fill_in 'Percentage Discount:', with: '30.5' 
     click_on 'Update Discount Information' 
 
-    expect(current_path).to eq "merchant/discount/#{discount_1b.id}"
+    expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1b.id}"
     expect(page).to have_content "Discount has been successfully updated."
-    expect(page).to have_content 'Quantity Threshold: 15'
+    expect(page).to have_content 'Quantity Threshold: 20'
     expect(page).to have_content 'Percentage Discount: 30.5%'
   end
 end

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe 'Merchant Discount Edit Page', type: :feature do
     fill_in 'Number of an Item that must be bought to trigger the discount:', with: ''
     fill_in 'Percentage Discount:', with: 'forty' 
     click_on 'Update Discount Information' 
-    save_and_open_page
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1a.id}/edit"
     expect(page).to have_content "Error: Discount was not updated. Please fill out the form using numbers."

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe 'Merchant Discount Edit Page', type: :feature do
     fill_in 'Percentage Discount:', with: '30.5' 
     click_on 'Update Discount Information' 
 
-    
-
+    expect(current_path).to eq "merchant/discount/#{discount_1b.id}"
+    expect(page).to have_content "Discount has been successfully updated."
+    expect(page).to have_content 'Quantity Threshold: 15'
+    expect(page).to have_content 'Percentage Discount: 30.5%'
   end
 end

--- a/spec/features/merchants/discounts/show_spec.rb
+++ b/spec/features/merchants/discounts/show_spec.rb
@@ -41,10 +41,4 @@ RSpec.describe 'Merchant Discount Show page', type: :feature do
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1b.id}/edit"
   end
-
-
-  # And I see that the discounts current attributes are pre-poluated in the form
-  # When I change any/all of the information and click submit
-  # Then I am redirected to the bulk discount's show page
-  # And I see that the discount's attributes have been updated
 end

--- a/spec/features/merchants/discounts/show_spec.rb
+++ b/spec/features/merchants/discounts/show_spec.rb
@@ -21,4 +21,30 @@ RSpec.describe 'Merchant Discount Show page', type: :feature do
     expect(page).to_not have_content('Quantity Threshold: 15')
     expect(page).to_not have_content('Percentage Discount: 30.0%')
   end
+
+  # US 5
+  # Merchant Bulk Discount Edit
+  # As a merchant
+  # When I visit my bulk discount show page
+  # Then I see a link to edit the bulk discount
+  # When I click this link
+  # Then I am taken to a new page with a form to edit the discount
+  it 'has a link to edit the bulk discount' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    visit merchant_discount_path(merchant_1, discount_1b)
+    click_link 'Edit Discount'
+
+    expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1b.id}/edit"
+  end
+
+
+  # And I see that the discounts current attributes are pre-poluated in the form
+  # When I change any/all of the information and click submit
+  # Then I am redirected to the bulk discount's show page
+  # And I see that the discount's attributes have been updated
 end


### PR DESCRIPTION
Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated