### PR TITLE
US6 merchant invoice show page discounted revenue

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -4,8 +4,9 @@ class MerchantInvoicesController < ApplicationController
     end
 
     def show
-        @invoice = Invoice.find(params[:id])
-        @merchant = Merchant.find(params[:merchant_id])
+        @facade = MerchantInvoicesFacade.new(params)
+        # @invoice = Invoice.find(params[:id])
+        # @merchant = Merchant.find(params[:merchant_id])
     end
 
     def update

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -13,4 +13,8 @@ class MerchantInvoicesFacade
 
     discounts.sum
   end
+
+  def discounted_rev
+    @invoice.total_revenue - total_discounts
+  end
 end

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -5,4 +5,12 @@ class MerchantInvoicesFacade
     @merchant = Merchant.find(params[:merchant_id])
     @invoice = Invoice.find(params[:id])
   end
+
+  def total_discounts
+    discounts = @invoice.all_discounts.map do |invoice_item|  
+      invoice_item.item_discount
+    end
+
+    discounts.sum
+  end
 end

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -1,0 +1,8 @@
+class MerchantInvoicesFacade
+  attr_reader :merchant, :invoice  
+
+  def initialize(params)
+    @merchant = Merchant.find(params[:merchant_id])
+    @invoice = Invoice.find(params[:id])
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -20,7 +20,7 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items
     .joins(item: :merchant)
-    .select('invoice_items.invoice_id as inv_id, sum(invoice_items.quantity * invoice_items.unit_price) as rev')
+    .select('invoice_items.invoice_id as inv_id, sum(invoice_items.quantity * invoice_items.unit_price/100.0) as rev')
     .group('inv_id')[0]
     .rev 
     # revenue_generated = 0
@@ -34,7 +34,7 @@ class Invoice < ApplicationRecord
     test = invoice_items
     .joins(item: [{merchant: :discounts}])
     .where('quantity >= discounts.threshold')
-    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price as item_discount')
+    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
     .group(:id)
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,7 +31,8 @@ class Invoice < ApplicationRecord
   end
 
   def total_discounts
-    invoice_items
+    binding.pry 
+    test = invoice_items
     .joins(item: [{merchant: :discounts}])
     .where('quantity >= discounts.threshold')
     .select('max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price as item_discount')

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -30,12 +30,11 @@ class Invoice < ApplicationRecord
     # revenue_generated
   end
 
-  def total_discounts
-    binding.pry 
+  def all_discounts
     test = invoice_items
     .joins(item: [{merchant: :discounts}])
     .where('quantity >= discounts.threshold')
-    .select('max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price as item_discount')
+    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price as item_discount')
     .group(:id)
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -18,10 +18,23 @@ class Invoice < ApplicationRecord
   end
 
   def total_revenue
-    revenue_generated = 0
-    invoice_items.each do |invoice_item|
-      revenue_generated += (invoice_item.quantity * invoice_item.unit_price)
-    end
-    revenue_generated
+    invoice_items
+    .joins(item: :merchant)
+    .select('invoice_items.invoice_id as inv_id, sum(invoice_items.quantity * invoice_items.unit_price) as rev')
+    .group('inv_id')[0]
+    .rev 
+    # revenue_generated = 0
+    # invoice_items.each do |invoice_item|
+    #   revenue_generated += (invoice_item.quantity * invoice_item.unit_price)
+    # end
+    # revenue_generated
+  end
+
+  def total_discounts
+    invoice_items
+    .joins(item: [{merchant: :discounts}])
+    .where('quantity >= discounts.threshold')
+    .select('max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price as item_discount')
+    .group(:id)
   end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -7,7 +7,7 @@
 
     <p> Status: <%= @facade.invoice.status %> </p>
     <p> Created on: <%= @facade.invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
-    <p> Total Revenue: <%= number_to_currency(@facade.merchant.total_revenue(@facade.invoice.id).to_f/100 ) %> </p>
+    <p> Total Revenue: <%= number_to_currency(@facade.invoice.total_revenue) %> </p>
     <h2> customer: </h2>
     <p>  <%= @facade.invoice.customer.first_name  %> <%= @facade.invoice.customer.last_name  %> </p>
 </div>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -1,15 +1,15 @@
 <div id="header">
-    <%= render "shared/merchant_header" %>
+    <%= render "shared/merchant_facade_header" %>
 </div>
 
 <div id=invoice-details>
-    <h1> Invoice #<%= @invoice.id %> </h1>
+    <h1> Invoice #<%= @facade.invoice.id %> </h1>
 
-    <p> Status: <%= @invoice.status %> </p>
-    <p> Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
-    <p> Total Revenue: <%= number_to_currency(@merchant.total_revenue(@invoice.id).to_f/100 ) %> </p>
+    <p> Status: <%= @facade.invoice.status %> </p>
+    <p> Created on: <%= @facade.invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
+    <p> Total Revenue: <%= number_to_currency(@facade.merchant.total_revenue(@facade.invoice.id).to_f/100 ) %> </p>
     <h2> customer: </h2>
-    <p>  <%= @invoice.customer.first_name  %> <%= @invoice.customer.last_name  %> </p>
+    <p>  <%= @facade.invoice.customer.first_name  %> <%= @facade.invoice.customer.last_name  %> </p>
 </div>
 <div id=item-details>
     <h2> Items on this invoice: </h2>
@@ -21,12 +21,12 @@
             <th>Unit Price</th>
             <th>Status</th>
         </tr>
-        <% @merchant.get_invoice_items(@invoice.id).each do |invoice_item| %>
+        <% @facade.merchant.get_invoice_items(@facade.invoice.id).each do |invoice_item| %>
             <tr>
                 <td><%= invoice_item.item.name %></td>
                 <td><%= invoice_item.quantity %></td>
                 <td><%= number_to_currency(invoice_item.unit_price.to_f/100 ) %></td>
-                <td><%= form_with url: "/merchants/#{@merchant.id}/invoices/#{@invoice.id}/?invoice_item_id=#{invoice_item.id}", method: :patch, local: true do |f| %>
+                <td><%= form_with url: "/merchants/#{@facade.merchant.id}/invoices/#{@facade.invoice.id}/?invoice_item_id=#{invoice_item.id}", method: :patch, local: true do |f| %>
                     <%= f.select :status, options_for_select(['pending', 'packaged', 'shipped'], invoice_item.status) %>
                     <%= f.submit "Update Item Status"%>
                     <% end %>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -5,9 +5,14 @@
 <div id=invoice-details>
     <h1> Invoice #<%= @facade.invoice.id %> </h1>
 
-    <p> Status: <%= @facade.invoice.status %> </p>
-    <p> Created on: <%= @facade.invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
-    <p> Total Revenue: <%= number_to_currency(@facade.invoice.total_revenue) %> </p>
+    <p> Status: <%= @facade.invoice.status %> </p><br>
+
+    <p> Created on: <%= @facade.invoice.created_at.strftime("%A, %B %d, %Y") %> </p><br>
+
+    <p> Total Revenue: <%= number_to_currency(@facade.invoice.total_revenue) %> </p><br>
+
+    <p> Total Discounted Revenue: <%= number_to_currency(@facade.discounted_rev) %> </p><br>
+    
     <h2> customer: </h2>
     <p>  <%= @facade.invoice.customer.first_name  %> <%= @facade.invoice.customer.last_name  %> </p>
 </div>

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
   end
 
   it 'returns the discounted total revenue' do 
+    merchant = Merchant.create!(name: 'amazon')
+        
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    InvoiceItem.create!(quantity: 15, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+
+    discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
     
+    expect(mif.discounted_rev).to eq 1575.0
   end
 end

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -30,4 +30,34 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
 
     expect(mif.invoice).to eq invoice_1
   end
+
+  it 'returns the total discounts' do 
+    merchant = Merchant.create!(name: 'amazon')
+        
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    InvoiceItem.create!(quantity: 15, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+
+    discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
+    
+    expect(mif.total_discounts).to eq 675.0
+  end
+
+  it 'returns the discounted total revenue' do 
+    
+  end
 end

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
 
     invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-    InvoiceItem.create!(quantity: 15, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
-    InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
 
     discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
     discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
@@ -67,8 +67,8 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
 
     invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-    InvoiceItem.create!(quantity: 15, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
-    InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
 
     discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
     discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper' 
+
+RSpec.describe 'Merchant Invoices Facade', type: :facade do 
+  it 'has a Merchant' do 
+    merchant = Merchant.create!(name: 'amazon')
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
+
+    expect(mif.merchant).to eq merchant
+  end
+
+  it 'has an Invoice' do 
+    merchant = Merchant.create!(name: 'amazon')
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
+
+    expect(mif.invoice).to eq invoice_1
+  end
+end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'Merchant invoice Show page' do
         item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
         invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-
         InvoiceItem.create!(quantity: 2, unit_price: 11, status: 'shipped', item: item_1, invoice: invoice_1)
         InvoiceItem.create!(quantity: 10, unit_price: 500, status: 'packaged', item: item_2, invoice: invoice_1)
 
@@ -86,6 +85,35 @@ RSpec.describe 'Merchant invoice Show page' do
             click_on("Update Item Status")
             expect(current_path).to eq("/merchants/#{merchant.id}/invoices/#{invoice_1.id}")
             expect(page).to have_content("packaged")
+        end
+    end
+
+    # US 6
+    # Merchant Invoice Show Page: Total Revenue and Discounted Revenue
+    # As a merchant
+    # When I visit my merchant invoice show page
+    # Then I see the total revenue for my merchant from this invoice (not including discounts)
+    # And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
+    it 'shows total discounted revenue generated from all items on invoice' do
+        merchant = Merchant.create!(name: 'amazon')
+        
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 2, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+
+        discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+        discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+        visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
+
+        within "#invoice-details" do
+            expect(page).to have_content("Total Discounted Revenue: $50.22")
         end
     end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Merchant invoice Show page' do
     # When I visit my merchant invoice show page
     # Then I see the total revenue for my merchant from this invoice (not including discounts)
     # And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
-    it 'shows total discounted revenue generated from all items on invoice' do
+    xit 'shows total discounted revenue generated from all items on invoice' do
         merchant = Merchant.create!(name: 'amazon')
         
         customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe 'Merchant invoice Show page' do
         item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
         invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-        InvoiceItem.create!(quantity: 2, unit_price: 11, status: 'shipped', item: item_1, invoice: invoice_1)
-        InvoiceItem.create!(quantity: 10, unit_price: 500, status: 'packaged', item: item_2, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 2, unit_price: 1100, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 10, unit_price: 50000, status: 'packaged', item: item_2, invoice: invoice_1)
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
 
@@ -95,7 +95,7 @@ RSpec.describe 'Merchant invoice Show page' do
     # When I visit my merchant invoice show page
     # Then I see the total revenue for my merchant from this invoice (not including discounts)
     # And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
-    xit 'shows total discounted revenue generated from all items on invoice' do
+    it 'shows total discounted revenue generated from all items on invoice' do
         merchant = Merchant.create!(name: 'amazon')
         
         customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
@@ -105,16 +105,16 @@ RSpec.describe 'Merchant invoice Show page' do
 
         invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-        InvoiceItem.create!(quantity: 2, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
-        InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
 
-        discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
-        discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+        discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+        discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
 
         within "#invoice-details" do
-            expect(page).to have_content("Total Discounted Revenue: $50.22")
+            expect(page).to have_content("Total Discounted Revenue: $1,150.00")
         end
     end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe 'Merchant invoice Show page' do
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
 
         within "#invoice-details" do
-            expect(page).to have_content("Total Revenue: $50.22")
+            expect(page).to have_content("Total Revenue: $5,022.00")
         end
+        # <p> Total Revenue: <%= number_to_currency(@facade.merchant.total_revenue(@facade.invoice.id).to_f/100 ) %> </p>
     end
 
     it 'has a select field to update the item status ' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -76,5 +76,28 @@ RSpec.describe Invoice, type: :model do
         expect(invoice_1.total_revenue).to eq(55000)
       end
     end
+
+    describe '#total_discounts' do 
+      it 'shows total discounted revenue generated from all items on invoice' do
+        merchant = Merchant.create!(name: 'amazon')
+        
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 2, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+
+        discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+        discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+        expected = invoice_1.total_discounts.map { |invoice_item| invoice_item.item_discount }.sum 
+
+        expect(expected).to eq 450.0 
+      end
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -49,31 +49,31 @@ RSpec.describe Invoice, type: :model do
           last_name: Faker::Name.unique.last_name)
 
         invoice_1 = Invoice.create!( status: 'completed', 
-                                      customer_id: customer_1.id)
+        customer_id: customer_1.id)
 
         item_1 = Item.create!(name: Faker::Commerce.unique.product_name, 
-                              description: 'Our first test item', 
-                              unit_price: rand(100..10000), 
-                              merchant_id: merchant_1.id)
+        description: 'Our first test item', 
+        unit_price: rand(100..10000), 
+        merchant_id: merchant_1.id)
 
         item_2 = Item.create!(name: Faker::Commerce.unique.product_name, 
-                              description: 'Our second test item', 
-                              unit_price: rand(100..10000), 
-                              merchant_id: merchant_1.id)
+        description: 'Our second test item', 
+        unit_price: rand(100..10000), 
+        merchant_id: merchant_1.id)
 
         invoice_item_1 = InvoiceItem.create!(quantity: 1, 
-                                              unit_price: 5000, 
-                                              status: 'shipped', 
-                                              item_id: item_1.id, 
-                                              invoice_id: invoice_1.id)
+        unit_price: 5000, 
+        status: 'shipped', 
+        item_id: item_1.id, 
+        invoice_id: invoice_1.id)
 
-        invoice_item_2 = InvoiceItem.create!(quantity: 5, 
-                                              unit_price: 10000, 
-                                              status: 'shipped', 
-                                              item_id: item_2.id, 
-                                              invoice_id: invoice_1.id)
+        invoice_item_2 = InvoiceItem.create!(quantity: 5,
+        unit_price: 10000, 
+        status: 'shipped', 
+        item_id: item_2.id, 
+        invoice_id: invoice_1.id)
 
-        expect(invoice_1.total_revenue).to eq(55000)
+        expect(invoice_1.total_revenue).to eq(550)
       end
     end
 
@@ -88,8 +88,8 @@ RSpec.describe Invoice, type: :model do
 
         invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-        InvoiceItem.create!(quantity: 15, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
-        InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
 
         discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
         discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Invoice, type: :model do
     end
 
     describe '#total_discounts' do 
-      it 'shows total discounted revenue generated from all items on invoice' do
+      it 'shows total discount amount generated from all items on invoice' do
         merchant = Merchant.create!(name: 'amazon')
         
         customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
@@ -88,7 +88,7 @@ RSpec.describe Invoice, type: :model do
 
         invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-        InvoiceItem.create!(quantity: 2, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 50, status: 'shipped', item: item_1, invoice: invoice_1)
         InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item: item_2, invoice: invoice_1)
 
         discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Invoice, type: :model do
       end
     end
 
-    describe '#total_discounts' do 
-      it 'shows total discount amount generated from all items on invoice' do
+    describe '#all_discounts' do 
+      it 'shows all discounts generated from all items on invoice' do
         merchant = Merchant.create!(name: 'amazon')
         
         customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
@@ -94,9 +94,9 @@ RSpec.describe Invoice, type: :model do
         discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
         discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
 
-        expected = invoice_1.total_discounts.map { |invoice_item| invoice_item.item_discount }.sum 
+        expected = invoice_1.all_discounts.map { |invoice_item| invoice_item.item_discount }.sum 
 
-        expect(expected).to eq 450.0 
+        expect(expected).to eq 675.0 
       end
     end
   end


### PR DESCRIPTION
- implement MerchantInvoicesFacade 
- created #total_revenue and #all_discounts methods in Invoice Model 
- Merchant Invoice Show page displays the total revenue and total discount amount for the Invoice 

Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation