### PR TITLE
US7 merchant invoice show link to discounts

### DIFF
--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -20,8 +20,8 @@ class MerchantInvoicesFacade
 
   def discount_stats
     stats = Hash.new 
-    @invoice.all_discounts.map do |discount| 
-      stats[discount.discount_id.to_s] = "#{discount.max_disc}% off Discount with Threshold of #{discount.count_threshold} Applied"
+    @invoice.all_discounts.map do |invoice_item| 
+      stats[invoice_item.id.to_s] = [invoice_item.discount_id, "#{invoice_item.max_disc}% off Discount with Threshold of #{invoice_item.count_threshold} Applied"]
     end
     stats 
   end

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -19,8 +19,10 @@ class MerchantInvoicesFacade
   end
 
   def discount_stats
+    stats = Hash.new 
     @invoice.all_discounts.map do |discount| 
-      "#{discount.max_disc}% off Discount with Threshold of #{discount.count_threshold} Applied"
+      stats[discount.discount_id.to_s] = "#{discount.max_disc}% off Discount with Threshold of #{discount.count_threshold} Applied"
     end
+    stats 
   end
 end

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -21,6 +21,7 @@ class MerchantInvoicesFacade
   def discount_stats
     stats = Hash.new 
     @invoice.all_discounts.map do |invoice_item| 
+      binding.pry 
       stats[invoice_item.id.to_s] = [invoice_item.discount_id, "#{invoice_item.max_disc}% off Discount with Threshold of #{invoice_item.count_threshold} Applied"]
     end
     stats 

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -17,4 +17,10 @@ class MerchantInvoicesFacade
   def discounted_rev
     @invoice.total_revenue - total_discounts
   end
+
+  def discount_stats
+    @invoice.all_discounts.map do |discount| 
+      "#{discount.max_disc}% off Discount with Threshold of #{discount.count_threshold} Applied"
+    end
+  end
 end

--- a/app/facades/merchant_invoices_facade.rb
+++ b/app/facades/merchant_invoices_facade.rb
@@ -21,7 +21,6 @@ class MerchantInvoicesFacade
   def discount_stats
     stats = Hash.new 
     @invoice.all_discounts.map do |invoice_item| 
-      binding.pry 
       stats[invoice_item.id.to_s] = [invoice_item.discount_id, "#{invoice_item.max_disc}% off Discount with Threshold of #{invoice_item.count_threshold} Applied"]
     end
     stats 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -37,5 +37,6 @@ class Invoice < ApplicationRecord
     .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.threshold) as count_threshold, max(discounts.id) as discount_id, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
     .group(:id)
     .order(:id)
+    binding.pry 
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -34,7 +34,7 @@ class Invoice < ApplicationRecord
     test = invoice_items
     .joins(item: [{merchant: :discounts}])
     .where('quantity >= discounts.threshold')
-    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.threshold) as count_threshold, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
+    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.threshold) as count_threshold, max(discounts.id) as discount_id, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
     .group(:id)
     .order(:id)
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -37,6 +37,5 @@ class Invoice < ApplicationRecord
     .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.threshold) as count_threshold, max(discounts.id) as discount_id, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
     .group(:id)
     .order(:id)
-    binding.pry 
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -34,7 +34,8 @@ class Invoice < ApplicationRecord
     test = invoice_items
     .joins(item: [{merchant: :discounts}])
     .where('quantity >= discounts.threshold')
-    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
+    .select('invoice_items.*, max(discounts.discount) as max_disc, max(discounts.threshold) as count_threshold, max(discounts.discount) / 100  * invoice_items.quantity * invoice_items.unit_price/100.0 as item_discount')
     .group(:id)
+    .order(:id)
   end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -18,7 +18,7 @@
   
 
   <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %> </p>
-  <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue.to_f/100)%></p>
+  <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue.to_f)%></p>
   <h2>Customer: </h2>
   <p><%= @invoice.customer.first_name.titlecase  %> <%= @invoice.customer.last_name.titlecase  %> </p>
 </div>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -33,7 +33,12 @@
                 <td><%= invoice_item.quantity %></td>
                 <td><%= number_to_currency(invoice_item.unit_price.to_f/100 ) %></td>
                 <td>
-                <%= link_to @facade.discount_stats[invoice_item.id.to_s][1], merchant_discount_path(@facade.merchant, @facade.discount_stats[invoice_item.id.to_s][0]) %></td>
+                    <% if @facade.discount_stats[invoice_item.id.to_s] == nil %>
+                        <%= 'N/A' %>
+                    <% else %>
+                        <%= link_to @facade.discount_stats[invoice_item.id.to_s][1], merchant_discount_path(@facade.merchant, @facade.discount_stats[invoice_item.id.to_s][0]) %>
+                    <% end %>
+                </td>
                 <td><%= form_with url: "/merchants/#{@facade.merchant.id}/invoices/#{@facade.invoice.id}/?invoice_item_id=#{invoice_item.id}", method: :patch, local: true do |f| %>
                     <%= f.select :status, options_for_select(['pending', 'packaged', 'shipped'], invoice_item.status) %>
                     <%= f.submit "Update Item Status"%>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -13,6 +13,8 @@
 
     <p> Total Discounted Revenue: <%= number_to_currency(@facade.discounted_rev) %> </p><br>
     
+    <% binding.pry %>
+
     <h2> customer: </h2>
     <p>  <%= @facade.invoice.customer.first_name  %> <%= @facade.invoice.customer.last_name  %> </p>
 </div>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -13,7 +13,10 @@
 
     <p> Total Discounted Revenue: <%= number_to_currency(@facade.discounted_rev) %> </p><br>
     
-    <% binding.pry %>
+    <% @facade.discount_stats.each do |discount_id, string| %>
+        <%= link_to string, merchant_discount_path(discount_id.to_i) %>
+        <br>
+    <% end %>
 
     <h2> customer: </h2>
     <p>  <%= @facade.invoice.customer.first_name  %> <%= @facade.invoice.customer.last_name  %> </p>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -14,7 +14,7 @@
     <p> Total Discounted Revenue: <%= number_to_currency(@facade.discounted_rev) %> </p><br>
     
     <% @facade.discount_stats.each do |discount_id, string| %>
-        <%= link_to string, merchant_discount_path(discount_id.to_i) %>
+        <%= link_to string, merchant_discount_path(@facade.merchant, discount_id.to_i) %>
         <br>
     <% end %>
 

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -32,7 +32,8 @@
                 <td><%= invoice_item.item.name %></td>
                 <td><%= invoice_item.quantity %></td>
                 <td><%= number_to_currency(invoice_item.unit_price.to_f/100 ) %></td>
-                <td><%= link_to @facade.discount_stats[invoice_item.id.to_s][1], merchant_discount_path(@facade.merchant, @facade.discount_stats[invoice_item.id.to_s][0]) %></td>
+                <td>
+                <%= link_to @facade.discount_stats[invoice_item.id.to_s][1], merchant_discount_path(@facade.merchant, @facade.discount_stats[invoice_item.id.to_s][0]) %></td>
                 <td><%= form_with url: "/merchants/#{@facade.merchant.id}/invoices/#{@facade.invoice.id}/?invoice_item_id=#{invoice_item.id}", method: :patch, local: true do |f| %>
                     <%= f.select :status, options_for_select(['pending', 'packaged', 'shipped'], invoice_item.status) %>
                     <%= f.submit "Update Item Status"%>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -12,11 +12,6 @@
     <p> Total Revenue: <%= number_to_currency(@facade.invoice.total_revenue) %> </p><br>
 
     <p> Total Discounted Revenue: <%= number_to_currency(@facade.discounted_rev) %> </p><br>
-    
-    <% @facade.discount_stats.each do |discount_id, string| %>
-        <%= link_to string, merchant_discount_path(@facade.merchant, discount_id.to_i) %>
-        <br>
-    <% end %>
 
     <h2> customer: </h2>
     <p>  <%= @facade.invoice.customer.first_name  %> <%= @facade.invoice.customer.last_name  %> </p>
@@ -29,6 +24,7 @@
             <th>Item Name</th>
             <th>Quantity</th>
             <th>Unit Price</th>
+            <th>Discounts Applied</th>
             <th>Status</th>
         </tr>
         <% @facade.merchant.get_invoice_items(@facade.invoice.id).each do |invoice_item| %>
@@ -36,6 +32,7 @@
                 <td><%= invoice_item.item.name %></td>
                 <td><%= invoice_item.quantity %></td>
                 <td><%= number_to_currency(invoice_item.unit_price.to_f/100 ) %></td>
+                <td><%= link_to @facade.discount_stats[invoice_item.id.to_s][1], merchant_discount_path(@facade.merchant, @facade.discount_stats[invoice_item.id.to_s][0]) %></td>
                 <td><%= form_with url: "/merchants/#{@facade.merchant.id}/invoices/#{@facade.invoice.id}/?invoice_item_id=#{invoice_item.id}", method: :patch, local: true do |f| %>
                     <%= f.select :status, options_for_select(['pending', 'packaged', 'shipped'], invoice_item.status) %>
                     <%= f.submit "Update Item Status"%>

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -82,4 +82,30 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
     
     expect(mif.discounted_rev).to eq 1575.0
   end
+
+  it 'returns the discount stats' do 
+    merchant = Merchant.create!(name: 'amazon')
+        
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    InvoiceItem.create!(quantity: 10, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
+
+    discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
+
+    expect(mif.discount_stats).to eq(['20.0% off Discount with Threshold of 10 Applied', '30.0% off Discount with Threshold of 15 Applied'])
+  end
 end

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -140,33 +140,4 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
       ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
     })
   end
-
-  it 'returns a string indicating no Discounts were applied to an InvoiceItem' do 
-    merchant = Merchant.create!(name: 'amazon')
-        
-    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
-
-    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
-    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
-
-    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
-
-    ii_1 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
-    ii_2 = InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
-
-    discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
-    discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
-
-    params = {
-      :merchant_id => merchant.id, 
-      :id => invoice_1.id 
-    }
-
-    mif = MerchantInvoicesFacade.new(params)
-
-    expect(mif.discount_display).to eq({
-      ii_1.id.to_s => [nil, 'N/A'], 
-      ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
-    })
-  end
 end

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -111,4 +111,62 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
       ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
     })
   end
+
+  it 'returns the discount stats' do 
+    merchant = Merchant.create!(name: 'amazon')
+        
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    ii_1 = InvoiceItem.create!(quantity: 10, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+    ii_2 = InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
+
+    discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
+
+    expect(mif.discount_stats).to eq({
+      ii_1.id.to_s => [discount_1a.id, '20.0% off Discount with Threshold of 10 Applied'], 
+      ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
+    })
+  end
+
+  it 'returns a string indicating no Discounts were applied to an InvoiceItem' do 
+    merchant = Merchant.create!(name: 'amazon')
+        
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+    ii_1 = InvoiceItem.create!(quantity: 1, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+    ii_2 = InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
+
+    discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+    params = {
+      :merchant_id => merchant.id, 
+      :id => invoice_1.id 
+    }
+
+    mif = MerchantInvoicesFacade.new(params)
+
+    expect(mif.discount_stats).to eq({
+      ii_1.id.to_s => [nil, 'N/A'], 
+      ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
+    })
+  end
 end

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
 
     mif = MerchantInvoicesFacade.new(params)
 
-    expect(mif.discount_stats).to eq({
+    expect(mif.discount_display).to eq({
       ii_1.id.to_s => [nil, 'N/A'], 
       ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
     })

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
 
     invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
 
-    InvoiceItem.create!(quantity: 10, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
-    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
+    ii_1 = InvoiceItem.create!(quantity: 10, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+    ii_2 = InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
 
     discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
     discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
@@ -107,8 +107,8 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
     mif = MerchantInvoicesFacade.new(params)
 
     expect(mif.discount_stats).to eq({
-      discount_1a.id.to_s => '20.0% off Discount with Threshold of 10 Applied', 
-      discount_1b.id.to_s => '30.0% off Discount with Threshold of 15 Applied'
+      ii_1.id.to_s => [discount_1a.id, '20.0% off Discount with Threshold of 10 Applied'], 
+      ii_2.id.to_s => [discount_1b.id, '30.0% off Discount with Threshold of 15 Applied']
     })
   end
 end

--- a/spec/facades/merchant_invoices_facade_spec.rb
+++ b/spec/facades/merchant_invoices_facade_spec.rb
@@ -106,6 +106,9 @@ RSpec.describe 'Merchant Invoices Facade', type: :facade do
 
     mif = MerchantInvoicesFacade.new(params)
 
-    expect(mif.discount_stats).to eq(['20.0% off Discount with Threshold of 10 Applied', '30.0% off Discount with Threshold of 15 Applied'])
+    expect(mif.discount_stats).to eq({
+      discount_1a.id.to_s => '20.0% off Discount with Threshold of 10 Applied', 
+      discount_1b.id.to_s => '30.0% off Discount with Threshold of 15 Applied'
+    })
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe 'Merchant invoice Show page' do
         discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
+        save_and_open_page
 
         within "#invoice-details" do
             expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -140,7 +140,6 @@ RSpec.describe 'Merchant invoice Show page' do
         discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
-        save_and_open_page
 
         within "#item-details" do
             expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -117,4 +117,33 @@ RSpec.describe 'Merchant invoice Show page' do
             expect(page).to have_content("Total Discounted Revenue: $1,150.00")
         end
     end
+
+    # US 7 
+    # Merchant Invoice Show Page: Link to applied discounts
+    # As a merchant
+    # When I visit my merchant invoice show page
+    # Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)
+    it 'has a link to the show page for the discounts applied' do 
+        merchant = Merchant.create!(name: 'amazon')
+        
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 10, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
+
+        discount_1a = merchant.discounts.create!(discount: 20, threshold: 10)
+        discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
+
+        visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
+
+        within "#invoice-details" do
+            expect(page).to have_link('20.0% off Discount Applied')
+            expect(page).to have_link('30.0% off Discount Applied')
+        end
+    end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -142,8 +142,8 @@ RSpec.describe 'Merchant invoice Show page' do
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
 
         within "#invoice-details" do
-            expect(page).to have_link('20.0% off Discount Applied')
-            expect(page).to have_link('30.0% off Discount Applied')
+            expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')
+            expect(page).to have_link('30.0% off Discount with Threshold of 15 Applied')
         end
     end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -145,6 +145,10 @@ RSpec.describe 'Merchant invoice Show page' do
         within "#invoice-details" do
             expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')
             expect(page).to have_link('30.0% off Discount with Threshold of 15 Applied')
+
+            click_link '30.0% off Discount with Threshold of 15 Applied'
         end
+
+        expect(current_path).to eq "/merchants/#{merchant.id}/discounts/#{discount_1b.id}"
     end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -140,15 +140,20 @@ RSpec.describe 'Merchant invoice Show page' do
         discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
+        save_and_open_page
 
         within "#item-details" do
             expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')
             expect(page).to have_link('30.0% off Discount with Threshold of 15 Applied')
 
             click_link '30.0% off Discount with Threshold of 15 Applied'
-            save_and_open_page
         end
 
         expect(current_path).to eq "/merchants/#{merchant.id}/discounts/#{discount_1b.id}"
     end
+
+    # <% @facade.discount_stats.each do |discount_id, string| %>
+    #     <%= link_to string, merchant_discount_path(@facade.merchant, discount_id.to_i) %>
+    #     <br>
+    # <% end %>
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'Merchant invoice Show page' do
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
 
-        within "#invoice-details" do
+        within "#item-details" do
             expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')
             expect(page).to have_link('30.0% off Discount with Threshold of 15 Applied')
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -140,13 +140,13 @@ RSpec.describe 'Merchant invoice Show page' do
         discount_1b = merchant.discounts.create!(discount: 30, threshold: 15)
 
         visit "/merchants/#{merchant.id}/invoices/#{invoice_1.id}"
-        save_and_open_page
 
         within "#invoice-details" do
             expect(page).to have_link('20.0% off Discount with Threshold of 10 Applied')
             expect(page).to have_link('30.0% off Discount with Threshold of 15 Applied')
 
             click_link '30.0% off Discount with Threshold of 15 Applied'
+            save_and_open_page
         end
 
         expect(current_path).to eq "/merchants/#{merchant.id}/discounts/#{discount_1b.id}"


### PR DESCRIPTION
Merchant Invoice Show Page: Link to applied discounts

As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)