### PR TITLE
US9 merchant discounts index holidays api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'httparty'
 
 group :test do
-  gem 'webmock'
-  gem 'vcr'
+  # gem 'webmock'
+  # gem 'vcr'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
-    crack (0.4.5)
-      rexml
     crass (1.0.6)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
@@ -91,7 +89,6 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    hashdiff (1.0.1)
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -168,7 +165,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
-    rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -231,16 +227,11 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    vcr (6.1.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.16.0)
-      addressable (>= 2.8.0)
-      crack (>= 0.3.2)
-      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -274,9 +265,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
-  vcr
   web-console (>= 3.3.0)
-  webmock
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/app/facades/merchant_discounts_facade.rb
+++ b/app/facades/merchant_discounts_facade.rb
@@ -16,4 +16,27 @@ class MerchantDiscountsFacade
   def discount
     Discount.find(@params[:id])
   end
+
+  def holidays 
+    service.holidays.map do |data| 
+      Holiday.new(data)
+    end
+  end
+
+  def service 
+    HolidayService.new 
+  end
+
+  def next_3_holidays
+    arr = []
+    test = holidays.each do |holiday| 
+      if holiday.global == true 
+        arr << "#{holiday.name}: #{holiday.date}"
+        break if arr.compact.count == 3
+      else 
+        next
+      end 
+    end 
+    arr 
+  end
 end

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,9 @@
+class Holiday 
+  attr_reader :name, :date, :global 
+
+  def initialize(data)
+    @name = data[:localName]
+    @date = data[:date]
+    @global = data[:global]
+  end
+end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,10 @@
+class HolidayService 
+  def holidays 
+    get_url("/NextPublicHolidays/US")
+  end
+
+  def get_url(end_point)
+    response = HTTParty.get("https://date.nager.at/api/v3#{end_point}")
+    parsed = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -24,9 +24,9 @@
 <% end %>
 
 <div id='holidays'>
-<h3>Upcoming Holidays</h3>
+<h3>Upcoming Holidays</h3><br>
     <% @facade.next_3_holidays.each do |holiday| %>
-        <%= holiday %>
+        <%= holiday %><br>
     <% end %>
 </div>
 

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -23,5 +23,12 @@
     </div>
 <% end %>
 
+<div id='holidays'>
+<h3>Upcoming Holidays</h3>
+    <% @facade.next_3_holidays.each do |holiday| %>
+        <%= holiday %>
+    <% end %>
+</div>
+
 
 

--- a/spec/facades/merchant_discounts_facade_spec.rb
+++ b/spec/facades/merchant_discounts_facade_spec.rb
@@ -77,4 +77,23 @@ RSpec.describe 'MerchantDiscountsFacade', type: :facade do
 
     expect(mdf.discount).to eq discount_1a
   end
+
+  it 'returns the next 3 US holidays' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    params = {
+      :controller =>"merchant_discounts", 
+      :action =>"show", 
+      :merchant_id => merchant_1.id.to_s, 
+      :id => discount_1a.id.to_s 
+    } 
+
+    mdf = MerchantDiscountsFacade.new(params)
+
+    expect(mdf.next_3_holidays).to eq(["Labor Day: 2022-09-05", "Veterans Day: 2022-11-11", "Thanksgiving Day: 2022-11-24"])
+  end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
     discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
 
     visit merchant_discounts_path(merchant_1)
+    save_and_open_page
     
     within('#holidays') do 
       expect(page).to have_content "Upcoming Holidays"

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -98,4 +98,28 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
     expect(page).to have_content 'Discount has been successfully deleted.' 
     expect(page).to_not have_content 'Discount Amount: 20.0 percent, Threshold: 10 items'
   end
+
+  # US 9
+  # As a merchant
+  # When I visit the discounts index page
+  # I see a section with a header of "Upcoming Holidays"
+  # In this section the name and date of the next 3 upcoming US holidays are listed.
+  # Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)
+  # https://date.nager.at/api/v3/NextPublicHolidays/US
+  it 'has a Holidays section with the next 3 upcoming US holidays' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    visit merchant_discounts_path(merchant_1)
+    
+    within('#holidays') do 
+      expect(page).to have_content "Upcoming Holidays"
+      expect(page).to have_content "Labor Day: 2022-09-05" 
+      expect(page).to have_content "Veterans Day: 2022-11-11" 
+      expect(page).to have_content "Thanksgiving Day: 2022-11-24" 
+    end
+  end 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,40 +16,40 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'webmock/rspec'
+# require 'webmock/rspec'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
 
-  config.before(:each) do
-    json_response_repo = File.read('spec/fixtures/repo.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop").
-        to_return(status: 200, body: json_response_repo)
+  # config.before(:each) do
+  #   json_response_repo = File.read('spec/fixtures/repo.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop").
+  #       to_return(status: 200, body: json_response_repo)
 
-    json_response_contributors = File.read('spec/fixtures/repo_contributors.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/contributors").
-        to_return(status: 200, body: json_response_contributors)
+  #   json_response_contributors = File.read('spec/fixtures/repo_contributors.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/contributors").
+  #       to_return(status: 200, body: json_response_contributors)
 
-    json_response_commits_blake = File.read('spec/fixtures/repo_commits_blake.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=blakesaylor&per_page=100").
-        to_return(status: 200, body: json_response_commits_blake)
+  #   json_response_commits_blake = File.read('spec/fixtures/repo_commits_blake.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=blakesaylor&per_page=100").
+  #       to_return(status: 200, body: json_response_commits_blake)
 
-    json_response_commits_mayu = File.read('spec/fixtures/repo_commits_mayu.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=okayama-mayu&per_page=100").
-        to_return(status: 200, body: json_response_commits_mayu)
+  #   json_response_commits_mayu = File.read('spec/fixtures/repo_commits_mayu.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=okayama-mayu&per_page=100").
+  #       to_return(status: 200, body: json_response_commits_mayu)
 
-    json_response_commits_mike = File.read('spec/fixtures/repo_commits_mike.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=mkbonini&per_page=100").
-        to_return(status: 200, body: json_response_commits_mike)
+  #   json_response_commits_mike = File.read('spec/fixtures/repo_commits_mike.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=mkbonini&per_page=100").
+  #       to_return(status: 200, body: json_response_commits_mike)
 
-    json_response_commits_thomas = File.read('spec/fixtures/repo_commits_thomas.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=EagleEye5085&per_page=100").
-        to_return(status: 200, body: json_response_commits_thomas)
+  #   json_response_commits_thomas = File.read('spec/fixtures/repo_commits_thomas.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/commits?author=EagleEye5085&per_page=100").
+  #       to_return(status: 200, body: json_response_commits_thomas)
 
-    json_response_pull_requests = File.read('spec/fixtures/repo_pull_requests.json')
-    stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/pulls?state=all").
-        to_return(status: 200, body: json_response_pull_requests)
-  end
+  #   json_response_pull_requests = File.read('spec/fixtures/repo_pull_requests.json')
+  #   stub_request(:get, "https://api.github.com/repos/okayama-mayu/little-esty-shop/pulls?state=all").
+  #       to_return(status: 200, body: json_response_pull_requests)
+  # end
   
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)