### PR TITLE
Extension cannot delete or edit Discount if tied to pending Invoice 

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -24,17 +24,6 @@ class MerchantDiscountsController < ApplicationController
     pending_invoice_check(facade)
   end
 
-  def pending_invoice_check(facade)
-    merchant = facade.merchant
-    if facade.discount_deletable?
-      facade.discount.destroy 
-
-      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
-    else 
-      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount cannot be deleted when an Invoice with the Discount is pending.'
-    end 
-  end
-
   def edit 
     @facade = MerchantDiscountsFacade.new(params)
   end
@@ -57,6 +46,17 @@ class MerchantDiscountsController < ApplicationController
     else 
       redirect_to new_merchant_discount_path(params[:merchant_id]), alert: "Error: Please fill in all fields with numbers."
     end
+  end
+
+  def pending_invoice_check(facade)
+    merchant = facade.merchant
+    if facade.discount_deletable?
+      facade.discount.destroy 
+
+      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
+    else 
+      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount cannot be deleted when an Invoice with the Discount is pending.'
+    end 
   end
 
   def update_router(facade)

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -25,7 +25,7 @@ class MerchantDiscountsController < ApplicationController
 
   def pending_invoice_check(discounts, params)
     merchant = Merchant.find(params[:merchant_id])
-    if merchant.has_pending 
+    if merchant.has_pending_invoice 
       flash[:alert] = 'Merchant has one or more Pending Invoices. Discount cannot be deleted when an Invoice is pending.'
       render :index 
     else 

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -21,11 +21,13 @@ class MerchantDiscountsController < ApplicationController
   def destroy 
     # discount = Discount.find(params[:id])
     facade = MerchantDiscountsFacade.new(params)
-    pending_invoice_check(facade)
+    destroy_pending_invoice_check(facade)
   end
 
   def edit 
     @facade = MerchantDiscountsFacade.new(params)
+
+    edit_pending_invoice_check
   end
 
   def update 
@@ -48,7 +50,7 @@ class MerchantDiscountsController < ApplicationController
     end
   end
 
-  def pending_invoice_check(facade)
+  def destroy_pending_invoice_check(facade)
     merchant = facade.merchant
     if facade.discount_deletable?
       facade.discount.destroy 
@@ -56,6 +58,12 @@ class MerchantDiscountsController < ApplicationController
       redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
     else 
       redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount cannot be deleted when an Invoice with the Discount is pending.'
+    end 
+  end
+
+  def edit_pending_invoice_check
+    if !@facade.discount_deletable?
+      redirect_to merchant_discount_path(params[:merchant_id], params[:id]), notice: 'Discount cannot be edited when an Invoice with the Discount is pending.'
     end 
   end
 

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -20,9 +20,19 @@ class MerchantDiscountsController < ApplicationController
 
   def destroy 
     discount = Discount.find(params[:id])
-    discount.destroy 
+    pending_invoice_check(discount, params)
+  end
 
-    redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
+  def pending_invoice_check(discounts, params)
+    merchant = Merchant.find(params[:merchant_id])
+    if merchant.has_pending 
+      flash[:alert] = 'Merchant has one or more Pending Invoices. Discount cannot be deleted when an Invoice is pending.'
+      render :index 
+    else 
+      discount.destroy 
+
+      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
+    end 
   end
 
   def edit 

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -19,8 +19,10 @@ class MerchantDiscountsController < ApplicationController
   end
 
   def destroy 
-    discount = Discount.find(params[:id])
-    pending_invoice_check(discount, params)
+    binding.pry 
+    # discount = Discount.find(params[:id])
+    facade = MerchantDiscountsFacade.new(params)
+    pending_invoice_check(facade, params)
   end
 
   def pending_invoice_check(discounts, params)

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -19,20 +19,19 @@ class MerchantDiscountsController < ApplicationController
   end
 
   def destroy 
-    binding.pry 
     # discount = Discount.find(params[:id])
     facade = MerchantDiscountsFacade.new(params)
-    pending_invoice_check(facade, params)
+    pending_invoice_check(facade)
   end
 
-  def pending_invoice_check(discounts, params)
-    merchant = Merchant.find(params[:merchant_id])
-    if merchant.has_pending_invoices?
-      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Merchant has one or more Pending Invoices. Discount cannot be deleted when an Invoice is pending.'
-    else 
-      discount.destroy 
+  def pending_invoice_check(facade)
+    merchant = facade.merchant
+    if facade.discount_deletable?
+      facade.discount.destroy 
 
       redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount has been successfully deleted.'
+    else 
+      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Discount cannot be deleted when an Invoice with the Discount is pending.'
     end 
   end
 

--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -25,9 +25,8 @@ class MerchantDiscountsController < ApplicationController
 
   def pending_invoice_check(discounts, params)
     merchant = Merchant.find(params[:merchant_id])
-    if merchant.has_pending_invoice 
-      flash[:alert] = 'Merchant has one or more Pending Invoices. Discount cannot be deleted when an Invoice is pending.'
-      render :index 
+    if merchant.has_pending_invoices?
+      redirect_to merchant_discounts_path(params[:merchant_id]), notice: 'Merchant has one or more Pending Invoices. Discount cannot be deleted when an Invoice is pending.'
     else 
       discount.destroy 
 

--- a/app/facades/merchant_discounts_facade.rb
+++ b/app/facades/merchant_discounts_facade.rb
@@ -39,4 +39,14 @@ class MerchantDiscountsFacade
     end 
     arr 
   end
+
+  def discount_deletable? 
+    pending_invoice = @merchant.pending_invoices
+    pending_invoice.each do |invoice| 
+      invoice.all_discounts.each do |inv_disc| 
+        return false if inv_disc.discount_id == discount.id 
+      end
+    end
+    return true 
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -38,8 +38,4 @@ class Invoice < ApplicationRecord
     .group(:id)
     .order(:id)
   end
-
-  def has_pending_invoice
-    binding.pry 
-  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -38,4 +38,8 @@ class Invoice < ApplicationRecord
     .group(:id)
     .order(:id)
   end
+
+  def has_pending_invoice
+    binding.pry 
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -91,4 +91,12 @@ class Merchant < ApplicationRecord
     .distinct
     .where('invoices.status = 0')
   end
+
+  def has_pending_invoices?
+    if pending_invoices.empty? 
+      return false 
+    else 
+      return true 
+    end
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -85,4 +85,10 @@ class Merchant < ApplicationRecord
     .first
     .date 
   end
+
+  def pending_invoices
+    invoices
+    .distinct
+    .where('invoices.status = 0')
+  end
 end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -558,8 +558,8 @@ RSpec.describe 'Merchant Dashboard' do
 
         visit "merchants/#{merchant_1.id}/dashboard" 
 
-        invoice_1a_date = invoice_1a.created_at.strftime("%A, %B%e, %Y")
-        invoice_1b_date = invoice_1b.created_at.strftime("%A, %B%e, %Y")
+        invoice_1a_date = invoice_1a.created_at.strftime("%A, %B %e, %Y")
+        invoice_1b_date = invoice_1b.created_at.strftime("%A, %B %e, %Y")
 
         within("#item-0") do 
             expect(page).to have_content(invoice_1a_date)

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
     Faker::UniqueGenerator.clear 
     merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
-    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
-    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant_1.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant_1.id)
 
     discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
     discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
@@ -151,6 +151,7 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts"
     expect(page).to have_content 'Merchant has one or more Pending Invoices. Discount cannot be deleted when an Invoice is pending.'
-    expect(page).to have_content('Discount Amount: 15.0 percent, Threshold: 30 items')
+    expect(page).to have_content('Discount Amount: 20.0 percent, Threshold: 10 items')
+    expect(page).to have_content('Discount Amount: 30.0 percent, Threshold: 15 items')
   end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -138,10 +138,10 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
 
     customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
 
-    invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+    invoice_1 = Invoice.create!(status: 'in progress', customer_id: customer.id)
 
-    InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
-    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'packaged', item: item_2, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'pending', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'pending', item: item_2, invoice: invoice_1)
 
     visit merchant_discounts_path(merchant_1)
     

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
     discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
 
     visit merchant_discounts_path(merchant_1)
-    save_and_open_page
     
     within('#holidays') do 
       expect(page).to have_content "Upcoming Holidays"
@@ -146,7 +145,7 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
     visit merchant_discounts_path(merchant_1)
     
     within('#discount-1') do 
-      click_link 'Delete Discount' 
+      click_link 'Delete Discount'
     end
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts"
@@ -179,7 +178,7 @@ RSpec.describe 'Merchant Discounts Index Page', type: :feature do
     end
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts"
-    expect(page).to have_content 'Discount was successfully deleted.'
+    expect(page).to have_content 'Discount has been successfully deleted.'
     expect(page).to_not have_content('Discount Amount: 20.0 percent, Threshold: 10 items')
     expect(page).to have_content('Discount Amount: 30.0 percent, Threshold: 15 items')
   end

--- a/spec/features/merchants/discounts/show_spec.rb
+++ b/spec/features/merchants/discounts/show_spec.rb
@@ -41,4 +41,33 @@ RSpec.describe 'Merchant Discount Show page', type: :feature do
 
     expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1b.id}/edit"
   end
+
+  # Extension 1 
+  # When an invoice is pending, a merchant should not be able to delete or edit a bulk discount that applies to any of their items on that invoice.
+  it 'does not allow a Discount to be edited if the Merchant has a pending Invoice within which the Discount is applied' do 
+    Faker::UniqueGenerator.clear 
+    merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+    item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant_1.id)
+    item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant_1.id)
+
+    discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+    discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+    customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+    invoice_1 = Invoice.create!(status: 'in progress', customer_id: customer.id)
+
+    InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'pending', item: item_1, invoice: invoice_1)
+    InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'pending', item: item_2, invoice: invoice_1)
+
+    visit merchant_discount_path(merchant_1, discount_1b)
+
+    click_link 'Edit Discount'
+
+    expect(current_path).to eq "/merchants/#{merchant_1.id}/discounts/#{discount_1b.id}"
+    expect(page).to have_content 'Discount cannot be edited when an Invoice with the Discount is pending.'
+    expect(page).to have_content('Quantity Threshold: 15')
+    expect(page).to have_content('Percentage Discount: 30.0%')
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -505,5 +505,32 @@ RSpec.describe Merchant, type: :model do
         expect(merchant_1.pending_invoices).to eq [invoice_2]
       end
     end
+
+    describe '#has_pending_invoices?' do 
+      it 'returns true if the Merchant has any pending invoices' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant_1.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant_1.id)
+
+        discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+        discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 20, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 1, unit_price: 10000, status: 'shipped', item: item_2, invoice: invoice_1)
+
+        invoice_2 = Invoice.create!(status: 'in progress', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'pending', item: item_1, invoice: invoice_2)
+        InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'pending', item: item_2, invoice: invoice_2)
+
+        expect(merchant_1.has_pending_invoices?).to eq true 
+      end
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -479,13 +479,13 @@ RSpec.describe Merchant, type: :model do
       end
     end
 
-    describe '#has_pending_invoice' do 
-      it 'returns true if Merchant has any pending Invoices' do 
+    describe '#pending_invoices' do 
+      it 'returns the pending invoices of a Merchant' do 
         Faker::UniqueGenerator.clear 
         merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
-        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
-        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant_1.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant_1.id)
 
         discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
         discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
@@ -502,7 +502,7 @@ RSpec.describe Merchant, type: :model do
         InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'pending', item: item_1, invoice: invoice_2)
         InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'pending', item: item_2, invoice: invoice_2)
 
-        expect(merchant.has_pending_invoice).to eq true 
+        expect(merchant_1.pending_invoices).to eq [invoice_2]
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -478,5 +478,32 @@ RSpec.describe Merchant, type: :model do
         expect(merchant_1.best_day).to eq time_2020
       end
     end
+
+    describe '#has_pending_invoice' do 
+      it 'returns true if Merchant has any pending Invoices' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+
+        discount_1a = merchant_1.discounts.create!(discount: 20, threshold: 10)
+        discount_1b = merchant_1.discounts.create!(discount: 30, threshold: 15)
+
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 20, unit_price: 5000, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 1, unit_price: 10000, status: 'shipped', item: item_2, invoice: invoice_1)
+
+        invoice_2 = Invoice.create!(status: 'in progress', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 2, unit_price: 5000, status: 'pending', item: item_1, invoice: invoice_2)
+        InvoiceItem.create!(quantity: 15, unit_price: 10000, status: 'pending', item: item_2, invoice: invoice_2)
+
+        expect(merchant.has_pending_invoice).to eq true 
+      end
+    end
   end
 end


### PR DESCRIPTION
When an invoice is pending, a merchant should not be able to delete or edit a bulk discount that applies to any of their items on that invoice.